### PR TITLE
Fix broken from_local usage examples in backend module docstrings.

### DIFF
--- a/gnm/shape/gnm_jax.py
+++ b/gnm/shape/gnm_jax.py
@@ -16,21 +16,23 @@
 
 Usage:
   ```
-  gnm = gnm_jax.from_local(version=GNMVersion.V3, variant=GNMVariant.HEAD)
+  gnm = gnm_jax.GNM.from_local(
+      version=gnm_jax.GNMMajorVersion.V3, variant=gnm_jax.GNMVariant.HEAD
+  )
 
   # Generate batches of parameters.
   n_batch = 5
-  identity = np.random.uniform(shape=(n_batch, gnm.identity_dim))
-  expression = np.random.uniform(shape=(n_batch, gnm.expression_dim))
-  rotations = np.random.uniform(shape=[n_batch, gnm.num_joints, 3])
-  translation = np.random.uniform(shape=(n_batch, 3))
+  identity = np.random.uniform(size=(n_batch, gnm.identity_dim))
+  expression = np.random.uniform(size=(n_batch, gnm.expression_dim))
+  rotations = np.random.uniform(size=[n_batch, gnm.num_joints, 3])
+  translation = np.random.uniform(size=(n_batch, 3))
   vertices = gnm(identity, expression, rotations, translation)
   ```
 
   # This module is differentiable.
   grad_func = jax.grad(
      lambda *args: jnp.square(gnm(*args)).mean(),
-     argnums=np.Array([0, 1, 2, 3]))
+     argnums=(0, 1, 2, 3))
   grads = grad_func(identity, expression, rotations, translation)
 """
 

--- a/gnm/shape/gnm_numpy.py
+++ b/gnm/shape/gnm_numpy.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NumPy implementation of the GNM model .
+"""NumPy implementation of the GNM model.
 
 Example usage:
   ```
-  gnm = gnm_numpy.from_local(version=GNMVersion.V3, variant=GNMVariant.HEAD)
+  gnm = gnm_numpy.GNM.from_local(
+      version=gnm_numpy.GNMMajorVersion.V3, variant=gnm_numpy.GNMVariant.HEAD
+  )
 
   # Generate random identity, expression, rotations, translation parameters
   identity = np.random.normal(size=gnm.identity_dim)

--- a/gnm/shape/gnm_pytorch.py
+++ b/gnm/shape/gnm_pytorch.py
@@ -16,7 +16,10 @@
 
 Usage:
   ```
-  gnm = gnm_pytorch.from_local(version=GNMVersion.V3, variant=GNMVariant.HEAD)
+  gnm = gnm_pytorch.GNM.from_local(
+      version=gnm_pytorch.GNMMajorVersion.V3,
+      variant=gnm_pytorch.GNMVariant.HEAD,
+  )
 
   # Generate batches of parameters.
   n_batch = 5

--- a/gnm/shape/gnm_tensorflow.py
+++ b/gnm/shape/gnm_tensorflow.py
@@ -16,9 +16,9 @@
 
 Usage:
   ```
-  gnm = gnm_tensorflow.from_local(
-      version=GNMVersion.V3,
-      variant=GNMVariant.HEAD
+  gnm = gnm_tensorflow.GNM.from_local(
+      version=gnm_tensorflow.GNMMajorVersion.V3,
+      variant=gnm_tensorflow.GNMVariant.HEAD,
   )
 
   # Generate batches of parameters.


### PR DESCRIPTION
The usage examples in the module docstrings of `gnm_numpy.py`, `gnm_jax.py`,
  `gnm_pytorch.py`, and `gnm_tensorflow.py` are not runnable as written:

  - They call `<module>.from_local(...)`, but no module-level `from_local`
    exists — it is a classmethod on the `GNM` class. Running the snippet raises
    `AttributeError: module 'gnm.shape.gnm_numpy' has no attribute 'from_local'`.
  - They pass `version=GNMVersion.V3`, but `V3` is not a member of `GNMVersion`
    (that enum has `V3_0`), and `GNM.from_local` is annotated to take
    `GNMMajorVersion`.

  This PR updates all four examples to
  `<module>.GNM.from_local(version=<module>.GNMMajorVersion.V3, variant=<module>.GNMVariant.HEAD)`
  so they are copy-paste runnable.

  It also fixes the remaining errors in the `gnm_jax.py` example:
  `np.random.uniform` takes `size=`, not `shape=`; `np.Array` does not exist and
  `jax.grad`'s `argnums` expects ints, so it now uses `argnums=(0, 1, 2, 3)`.
  Plus a stray space in the `gnm_numpy.py` docstring title.

  **Verification:** ran the corrected `gnm_numpy` example verbatim against the
  bundled V3 head model, it constructs the model and returns a `(17821, 3)`
  vertex array, where the previous snippet raised `AttributeError`. Docstring-only
  change; no behavior affected, all lines within 80 columns.