### PR TITLE
Include gnm.shape.data packages in setuptools package list.

### DIFF
--- a/gnm/shape/pyproject.toml
+++ b/gnm/shape/pyproject.toml
@@ -63,6 +63,8 @@ dev = [
 [tool.setuptools]
 packages = [
     "gnm.shape",
+    "gnm.shape.data",
+    "gnm.shape.data.versions",
     "gnm.shape.fitting_utils",
     "gnm.shape.visualization",
 ]


### PR DESCRIPTION
`gnm_base.py`, `gnm_data_loader.py`, and `gnm_landmarks.py` import
  `gnm.shape.data.versions.gnm_specs` and `gnm_catalog` as regular Python
  modules, but the `[tool.setuptools] packages` list in `pyproject.toml` does not
  declare `gnm.shape.data` or `gnm.shape.data.versions`. The `package-data` globs
  only cover asset files (`npz`, images, `md`, `h5`), so built distributions omit
  `gnm_specs.py` and `gnm_catalog.py` entirely.

  As a result, installing `gnm-shape` from a built wheel (`pip install .` without
  `-e`, or a wheel from `python -m build`) fails at import time:

      ImportError: cannot import name 'gnm_specs' from
      'gnm.shape.data.versions' (unknown location)

  CI does not catch this because all workflows install the package in editable
  mode (`pip install -e`), which puts the whole source tree on `sys.path`.

  **Fix:** declare the two missing packages in the `packages` list.

  **Verification:** built a wheel before and after this change. Before, the wheel
  contains no `.py` files under `gnm/shape/data/` and importing
  `gnm.shape.gnm_numpy` from the installed wheel raises the `ImportError` above.
  After, `gnm_specs.py` and `gnm_catalog.py` are included (the `.npz` model asset
  ships correctly in both cases) and `GNM.from_local` works from the installed
  wheel, returning the expected `(17821, 3)` vertex array.