### PR TITLE
Standardize G-Nome -> GNM in docstrings and a test name

### DIFF
--- a/gnm/shape/gnm_jupyter_viewer.py
+++ b/gnm/shape/gnm_jupyter_viewer.py
@@ -12,7 +12,7 @@ _get_vertex_colors = vertex_colors_module.get_vertex_colors
 
 
 class GNMMeshViewer:
-  """Sets up a three.js viewer for G-Nome meshes in Jupyter Notebook."""
+  """Sets up a three.js viewer for GNM meshes in Jupyter Notebook."""
 
   def __init__(
       self,
@@ -207,7 +207,7 @@ class GNMMeshViewer:
     display(Javascript(js_code))
 
   def update(self, vertices: np.ndarray) -> None:
-    """Update G-Nome mesh vertices."""
+    """Update GNM mesh vertices."""
     self.vertices = vertices
     vertices_list = vertices.ravel().tolist()
     js_code = f"""

--- a/gnm/shape/gnm_xnp.py
+++ b/gnm/shape/gnm_xnp.py
@@ -148,7 +148,7 @@ class GNM(gnm_base.GNMBase):
 
   @property
   def xnp(self) -> enp.NpModule:
-    """Returns the backend module dynamically from G-Nome array state."""
+    """Returns the backend module dynamically from GNM array state."""
     return self._xnp
 
   def __getstate__(self):

--- a/gnm/shape/semantic_sampler_test.py
+++ b/gnm/shape/semantic_sampler_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for G-Nome identity and expression sampler."""
+"""Tests for GNM identity and expression sampler."""
 
 # pylint: disable=protected-access
 

--- a/gnm/shape/visualization/gnm_pyrender_test.py
+++ b/gnm/shape/visualization/gnm_pyrender_test.py
@@ -32,7 +32,7 @@ _MAJOR_VERSION_TO_VARIANTS_MAP = gnm_catalog.MAJOR_VERSION_TO_VARIANTS_MAP
 _OUTPUTS_DIR = epath.Path(os.environ['TEST_UNDECLARED_OUTPUTS_DIR'])
 
 
-class GnomePyrenderTest(parameterized.TestCase):
+class GNMPyrenderTest(parameterized.TestCase):
 
   gnms: dict[str, gnm_numpy.GNM]
 


### PR DESCRIPTION
The codebase refers to the model as **GNM** everywhere except a few docstrings
and one test class name that used the `G-Nome` stylization:

- `gnm_jupyter_viewer.py` (two docstrings)
- `gnm_xnp.py` (one docstring)
- `semantic_sampler_test.py` (module docstring)
- `visualization/gnm_pyrender_test.py` (`GnomePyrenderTest` -> `GNMPyrenderTest`)

This standardizes them on the `GNM` acronym used throughout the rest of the
code. The "genome" pun remains in the README branding; this only touches
in-code identifiers and docstrings. No behavior change.

Happy to drop this if the `G-Nome` spelling is intentional in these spots.
