### PR TITLE
Fix crash in TensorFlow GNM compute_vertex_normals.

### DIFF
--- a/gnm/shape/gnm_tensorflow.py
+++ b/gnm/shape/gnm_tensorflow.py
@@ -125,14 +125,18 @@ class GNM(gnm_xnp.GNM):
     v2 = face_vertices[..., 2, :]
     face_normals_area = tf.experimental.numpy.cross(v1 - v0, v2 - v0, axis=-1)
 
-    data = tf.reshape(face_normals_area[:, :, None, :], (-1, 3))
+    # Replicate each face normal for the three corner vertices it contributes
+    # to, matching the flattened (triangle, corner) order of the segment ids.
+    data = tf.reshape(
+        tf.tile(face_normals_area[:, :, None, :], [1, 1, 3, 1]), (-1, 3)
+    )
     segment_ids = tf.reshape(self.triangles, (-1,))
     segment_ids = tf.tile(segment_ids[None, :], [batch_size, 1])
 
     batch_offset = (
         tf.range(batch_size, dtype=segment_ids.dtype)[:, None] * num_vertices
     )
-    flat_segment_ids = segment_ids + batch_offset
+    flat_segment_ids = tf.reshape(segment_ids + batch_offset, (-1,))
     flat_normals = tf.math.unsorted_segment_sum(
         data, flat_segment_ids, num_segments=batch_size * num_vertices
     )

--- a/gnm/shape/gnm_tensorflow_test.py
+++ b/gnm/shape/gnm_tensorflow_test.py
@@ -110,6 +110,32 @@ class GNMTensorflowTest(parameterized.TestCase):
 
   @parameterized.product(
       version=_MAINTAINED_MAJOR_GNM_VERSIONS,
+      variant=tuple(_SUPPORTED_VARIANTS),
+      batch_dims=BATCH_DIMS,
+  )
+  def test_compute_vertex_normals_numpy_parity(
+      self, version: str, variant: str, batch_dims: tuple[int, ...]
+  ):
+    """Tests that TensorFlow vertex normals match the NumPy implementation."""
+    if variant not in self.gnms_np[version]:
+      self.skipTest(f'variant {variant} not supported in {version}.')
+    gnm_np = self.gnms_np[version][variant]
+    gnm_tf = self.gnms_tf[version][variant]
+
+    parameters_np = gnm_test_utils.random_gnm_parameters(
+        gnm_np, batch_shape=batch_dims, seed=self.rng
+    )
+    vertices_np = gnm_np(**parameters_np)
+    desired = gnm_np.compute_vertex_normals(vertices_np)
+
+    vertices_tf = tf.convert_to_tensor(vertices_np, dtype=tf.float32)
+    actual = gnm_tf.compute_vertex_normals(vertices_tf)
+
+    self.assertEqual(tuple(actual.shape), vertices_np.shape)
+    np.testing.assert_allclose(actual.numpy(), desired, atol=1e-4)
+
+  @parameterized.product(
+      version=_MAINTAINED_MAJOR_GNM_VERSIONS,
       variant=(gnm_tensorflow.GNMVariant.HEAD,),
       batch_size=[(), (2,), (2, 3)],
   )


### PR DESCRIPTION
`gnm_tensorflow.GNM.compute_vertex_normals` crashes on any real mesh:

      InvalidArgumentError: data.shape = [35324,3] does not start with
      segment_ids.shape = [1,105972] [Op:UnsortedSegmentSum]

  (Reproduced on the bundled V3 head model: the forward pass succeeds, then
  computing normals for the resulting `(1, 17821, 3)` vertices raises the above.)

  **Root cause:** the face-normals tensor `(B, T, 3)` is reshaped straight to
  `(B*T, 3)` without replicating each face normal for the three corner vertices
  it contributes to, while the segment ids enumerate all `B*T*3` triangle
  corners. `tf.math.unsorted_segment_sum` requires `segment_ids.shape` to be a
  prefix of `data.shape`, so the shapes can never match for a real mesh (`T > 1`).
  The numpy, jax, and pytorch backends all replicate the face normal across the
  three corners (e.g. the `np.add.at` broadcast in `gnm_numpy.py`); the
  TensorFlow backend was the only one missing this step and the only backend
  with no test coverage for `compute_vertex_normals`.

  **Fix:** tile the face normals across the corner axis before flattening
  (`(B, T, 3, 3)` → `(B·T·3, 3)`), and flatten the batch-offset segment ids to
  match, reproducing the numpy backend's semantics exactly.

  **Test:** adds `test_compute_vertex_normals_numpy_parity`, mirroring the
  existing `test_parity_with_gnm_numpy` pattern: TensorFlow normals must match
  the numpy implementation (itself validated against `tensorflow_graphics` in
  `gnm_numpy_test.py`) over unbatched and multi-dimensional batch shapes
  (`()`, `(1,)`, `(1,2)`, `(2,1,2)`). The new test fails with the
  `InvalidArgumentError` above before this fix and passes after; the full
  `gnm_tensorflow_test` module passes.