### PR TITLE
Fix docs, packaging, and minor code issues in gnm.shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/gnm/shape/README.md
+++ b/gnm/shape/README.md
@@ -40,7 +40,7 @@ gnm/shape/
 ├── fitting_utils/          # Shared optimization helper functions
 ├── visualization/          # Rendering and camera projection utilities
 ├── gnm_base.py             # Base GNM class definitions
-├── gnm_colab_viewer.py     # Colab 3D face model visualization tool
+├── gnm_jupyter_viewer.py   # Jupyter 3D face model visualization tool
 ├── gnm_data_loader.py      # Dynamic model loaders and checkers
 ├── gnm_data_schema.py      # Input/output data validation schemas
 ├── gnm_jax.py              # JAX implementation of GNM
@@ -101,7 +101,7 @@ cd gnm/gnm/shape
 
 ### Loading the GNM Model
 
-The core model can be loaded as follows. The necessary model data (`gnm.npz`)
+The core model can be loaded as follows. The necessary model data (`gnm_head.npz`)
 is included in this repository.
 
 ```python

--- a/gnm/shape/gnm_data_loader.py
+++ b/gnm/shape/gnm_data_loader.py
@@ -14,7 +14,6 @@
 
 """GNM data loader."""
 
-# from collections.abc import Mapping, Sequence
 from collections.abc import Sequence
 import functools
 from typing import Any
@@ -215,7 +214,7 @@ def _populate_legacy_vertex_group_aliases(data: dict[str, Any]) -> None:
   extra_group_names = []
   extra_group_weights = []
 
-  # Mapping to retrieve new vertex group name by combinating legacy ones.
+  # Mapping to retrieve new vertex group name by combining legacy ones.
   # Note that this list is not exhaustive, and mostly here to support the
   # standard API calls in third_party/py/gnm.
   vertex_group_mappings = {

--- a/gnm/shape/gnm_jupyter_viewer.py
+++ b/gnm/shape/gnm_jupyter_viewer.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """GNM Jupyter viewer."""
 
 import json

--- a/gnm/shape/gnm_tensorflow.py
+++ b/gnm/shape/gnm_tensorflow.py
@@ -91,7 +91,8 @@ class GNM(gnm_xnp.GNM):
     version: The version of the loaded GNM model.
     pose_correctives_regressor: Matrix for pose correctives, (9*J, 3*V).
     joint_regressor: Mapping from vertices to joints, (J, V).
-    bone_aligned_orientations: The bone-aligned rotations for each joint, (J, 3,
+    bone_aligned_template_joint_orientations: The bone-aligned rotations for each
+      joint, (J, 3,
       3). If they do not exist in the GNM npz, they are set to the identity
       matrix. Note that these are not used to compute the GNM joint and vertex
       positions.

--- a/gnm/shape/gnm_utils.py
+++ b/gnm/shape/gnm_utils.py
@@ -261,7 +261,7 @@ def _regions_to_coefficients(
   coeffs = np.zeros(batch_shape + (coeffs_dim,), dtype=dtype)
   for region_name, values in regions.items():
     if region_name not in region_indices:
-      gnm_type_name = getattr(gnm, 'model_type', 'unknown')
+      gnm_type_name = getattr(gnm, 'variant', 'unknown')
       raise ValueError(f'No region {region_name} in model {gnm_type_name}.')
     else:
       coeffs[..., region_indices[region_name]] = values
@@ -401,7 +401,7 @@ def identity_regions_dims(gnm: gnm_numpy.GNM) -> dict[str, int]:
 def joint_rotations_to_regions(
     joint_rotations: np.ndarray, gnm: gnm_numpy.GNM
 ) -> dict[str, np.ndarray]:
-  """Splits the joint rotations ([A1, ..., An], J, 3]) to invidual regions."""
+  """Splits the joint rotations ([A1, ..., An], J, 3]) to individual regions."""
   validate_gnm(gnm)
   joint_names: list[str] = get_gnm_attribute(gnm, 'joint_names')
   if len(joint_names) != joint_rotations.shape[-2]:

--- a/gnm/shape/pyproject.toml
+++ b/gnm/shape/pyproject.toml
@@ -75,5 +75,6 @@ package-dir = {"gnm.shape" = "."}
     "data/**/*.jpg",
     "data/**/*.md",
     "data/**/*.h5",
+    "data/**/*.txt",
     "assets/**/*",
 ]

--- a/gnm/shape/semantic_sampler.py
+++ b/gnm/shape/semantic_sampler.py
@@ -98,7 +98,7 @@ def _get_rng(rng: np.random.Generator | None) -> np.random.Generator:
 
 
 class ExpressionSampler:
-  """Samples expressions and identities from a Conditional VAE."""
+  """Samples expressions from a Conditional VAE."""
 
   def __init__(
       self,


### PR DESCRIPTION
Replaces #23, which GitHub auto-closed after a force-push that cleaned up
the branch. Same changes as #23, now without the accidentally committed
`__pycache__/*.pyc` files, plus a small `.gitignore` so they can't recur.

- README: correct viewer filename (gnm_colab_viewer.py ->
  gnm_jupyter_viewer.py) and model data filename (gnm.npz -> gnm_head.npz)
- pyproject: include data/**/*.txt so the landmark definition file (head_sparse_68.txt) is bundled on non-editable installs
- gnm_jupyter_viewer.py: add the missing Apache-2.0 license header
- gnm_utils: reference the existing 'variant' attribute instead of the non-existent 'model_type' in the region error message; fix "invidual" typo
- gnm_data_loader: drop the stale commented-out import; fix "combinating" typo
- semantic_sampler: ExpressionSampler docstring no longer claims to sample identities
- gnm_tensorflow: correct attribute name in the GNM docstring (bone_aligned_template_joint_orientations)
- add a top-level `.gitignore` for `__pycache__/` / `*.py[cod]`
