### PR TITLE
Fix PyTorch backend device placement so GNM runs on CUDA

### DIFF
--- a/gnm/shape/gnm_common.py
+++ b/gnm/shape/gnm_common.py
@@ -22,6 +22,22 @@ enpt = enp.typing
 _EPSILON = 1e-8
 
 
+def _constant_like(
+    values: Any,
+    reference_array: enpt.FloatArray['...'],
+    xnp: Any,
+    dtype: Any,
+) -> enpt.FloatArray['...']:
+  """Creates a constant array on the same device as `reference_array`.
+
+  For PyTorch this places the constant on `reference_array.device`; for other
+  backends it falls back to a plain `asarray`.
+  """
+  if enp.lazy.is_torch(reference_array):
+    return xnp.asarray(values, dtype=dtype, device=reference_array.device)
+  return xnp.asarray(values, dtype=dtype)
+
+
 def take(
     array: enpt.FloatArray['...'],
     indices: enpt.IntArray['...'],
@@ -48,6 +64,8 @@ def take(
     xnp = enp.lazy.get_xnp(array)
   if enp.lazy.is_torch_xnp(xnp):
     axis = axis % array.ndim
+    # index_select requires indices to live on the same device as `array`.
+    indices = xnp.as_tensor(indices, device=array.device)
     indices_shape = indices.shape
     if len(indices_shape) > 1:
       indices_flat = indices.reshape(-1)
@@ -184,7 +202,10 @@ def axis_angle_to_rotation_matrix(
 
   norm_squared = xnp.sum(xnp.square(axis_angle), axis=-1, keepdims=True)
   angle = xnp.sqrt(
-      xnp.maximum(norm_squared, xnp.asarray(epsilon, dtype=norm_squared.dtype))
+      xnp.maximum(
+          norm_squared,
+          _constant_like(epsilon, axis_angle, xnp, norm_squared.dtype),
+      )
   )
   axis = axis_angle / angle
 
@@ -275,8 +296,8 @@ def joint_transforms_world(
       joints, 2, (num_joints, 1, 4), dtype=joints.dtype
   )
   # Set the last element to 1.0.
-  bottom_row = bottom_row + xnp.asarray(
-      [0.0, 0.0, 0.0, 1.0], dtype=joints.dtype
+  bottom_row = bottom_row + _constant_like(
+      [0.0, 0.0, 0.0, 1.0], joints, xnp, joints.dtype
   )
 
   local_transforms = xnp.concatenate(

--- a/gnm/shape/gnm_pytorch.py
+++ b/gnm/shape/gnm_pytorch.py
@@ -131,6 +131,17 @@ class GNM(gnm_xnp.GNM, torch.nn.Module):
     """Creates a PyTorch GNM instance from model data."""
     return cls._from_model_data_with_xnp(model_data, xnp=torch)
 
+  @classmethod
+  def from_gnm(cls, gnm: gnm_xnp.GNM) -> GNM:
+    """Creates a PyTorch GNM from another GNM, preserving its device."""
+    new_gnm = super().from_gnm(gnm)
+    # `from_gnm` reconstructs the model from a NumPy data dict, so the new model
+    # is created on CPU. If the source model lives on another device, move the
+    # reconstructed model there to match.
+    if isinstance(gnm, torch.nn.Module):
+      new_gnm = new_gnm.to(gnm.template_vertex_positions.device)
+    return new_gnm
+
   def compute_vertex_normals(
       self,
       vertices: torch.Tensor,

--- a/gnm/shape/gnm_pytorch_test.py
+++ b/gnm/shape/gnm_pytorch_test.py
@@ -279,6 +279,7 @@ class GNMPytorchTest(parameterized.TestCase):
         gnm_pytorch.GNMMajorVersion(version.removeprefix('v')),
         gnm_pytorch.GNMVariant(variant_str),
     )
+    gnm_pruned.to(self.device)
 
     keep_vertices = gnm_np.quads[0]
     gnm_pruned.prune_vertices(keep_vertices)

--- a/gnm/shape/gnm_xnp.py
+++ b/gnm/shape/gnm_xnp.py
@@ -379,6 +379,10 @@ class GNM(gnm_base.GNMBase):
         translation=translation,
     )
     weights = enp.compat.astype(weights, vertices.dtype)
+    # The landmark tensors are cached lazily and may live on a different device
+    # than the (possibly moved) model; align them with the output vertices.
+    if enp.lazy.is_torch(vertices):
+      weights = weights.to(vertices.device)
 
     face_vertices = gnm_common.take(vertices, indices, axis=-2, xnp=self.xnp)
     landmarks = self.xnp.sum(face_vertices * weights[..., None], axis=-2)
@@ -634,6 +638,10 @@ class GNM(gnm_base.GNMBase):
     xnp = self.xnp
     num_vertices = self.num_vertices
     keep_vertices = xnp.asarray(keep_vertices, dtype=xnp.int32)
+    # Keep the index tensor on the same device as the model buffers so that all
+    # downstream gathers stay device-consistent.
+    if enp.lazy.is_torch(self.template_vertex_positions):
+      keep_vertices = keep_vertices.to(self.template_vertex_positions.device)
 
     self.template_vertex_positions = gnm_common.take(
         self.template_vertex_positions, keep_vertices, axis=0, xnp=xnp
@@ -729,8 +737,11 @@ def _scatter_indices(keep_vertices, num_vertices, xnp) -> Any:
         jnp.arange(len(keep_vertices), dtype=jnp.int32)
     )
   elif enp.lazy.is_torch_xnp(xnp):
-    mapper = xnp.full((num_vertices,), -1, dtype=xnp.int32)
-    mapper[keep_vertices] = xnp.arange(len(keep_vertices), dtype=xnp.int32)
+    device = keep_vertices.device
+    mapper = xnp.full((num_vertices,), -1, dtype=xnp.int32, device=device)
+    mapper[keep_vertices] = xnp.arange(
+        len(keep_vertices), dtype=xnp.int32, device=device
+    )
     return mapper
   else:
     mapper = np.full((num_vertices,), -1, dtype=np.int32)


### PR DESCRIPTION
## Summary

The PyTorch backend is unusable on GPU: after moving a model to CUDA
(e.g. `gnm.cuda()`), evaluation fails with device-mismatch errors such as:

```
RuntimeError: Expected all tensors to be on the same device, but got index is
on cpu, different from other tensors on cuda:0 (... wrapper_CUDA__index_select)
```

Several tensors are built on CPU (from Python literals, lazily-cached landmark
data, or freshly-reconstructed models) and then combined with model buffers that
have been moved to GPU. This never surfaces in CI because the CI matrix is
CPU-only (Linux/macOS/Windows, no GPU runner), so the whole GPU path is
untested.

With a CUDA device visible, `gnm_pytorch_test.py` fails **28 / 33**; with
`CUDA_VISIBLE_DEVICES=""` all pass. This PR makes the PyTorch backend
device-consistent so the model, landmarks, pruning, and `from_gnm` all work on
GPU.

## Changes

All changes are guarded by `is_torch` / `is_torch_xnp` checks, so the NumPy,
JAX, and TensorFlow backends are unaffected.

| File | Change |
| --- | --- |
| `gnm/shape/gnm_common.py` | `take()` moves `indices` onto the array's device before `index_select`. New `_constant_like()` helper places literal constants on the reference tensor's device for torch; used in `axis_angle_to_rotation_matrix` (epsilon) and `joint_transforms_world` (the `[0,0,0,1]` homogeneous row). |
| `gnm/shape/gnm_xnp.py` | Align lazily-cached landmark `weights` with the output device; place `keep_vertices` (`prune_vertices`) and the `_scatter_indices` mapper on the model's device. |
| `gnm/shape/gnm_pytorch.py` | Override `from_gnm` to move the reconstructed model onto the source model's device (`from_gnm` rebuilds from a NumPy dict, which always lands on CPU). |
| `gnm/shape/gnm_pytorch_test.py` | Fix a latent test bug: `test_prune_vertices` built `gnm_pruned` via `from_local` (CPU) but fed it GPU parameters. Added `gnm_pruned.to(self.device)`. |

## Testing

Validated locally on CUDA (torch 2.13 + cu130, Python 3.13):

- `gnm_pytorch_test.py`: **33 passed** on GPU, **33 passed** on CPU.
- Shared / other-backend suites (`gnm_numpy_test.py`, `gnm_xnp_test.py`,
  `gnm_base_test.py`, `gnm_utils_test.py`, `gnm_landmarks_test.py`):
  **155 passed, 2 skipped** — no regressions.

```bash
cd gnm/shape
python -m pytest gnm_pytorch_test.py -q                       # GPU
CUDA_VISIBLE_DEVICES="" python -m pytest gnm_pytorch_test.py -q # CPU
```