### PR TITLE
Deduplicate GNM edge list

### DIFF
--- a/gnm/shape/gnm_numpy_test.py
+++ b/gnm/shape/gnm_numpy_test.py
@@ -429,6 +429,9 @@ class GNMNumpyTest(parameterized.TestCase):
     np.testing.assert_array_equal(
         adjacency_matrix_quads, adjacency_matrix_edge_list
     )
+    self.assertLen(
+        gnm_np.edge_list, len(np.unique(gnm_np.edge_list, axis=0))
+    )
 
   @parameterized.parameters(get_group_subsets_test_cases())
   def test_group_subsets(self, version: str, variant: str, group_name: str):

--- a/gnm/shape/gnm_xnp.py
+++ b/gnm/shape/gnm_xnp.py
@@ -426,7 +426,7 @@ class GNM(gnm_base.GNMBase):
     e1 = quads.ravel()
     e2 = np.roll(quads, -1, axis=1).ravel()
     edges = np.stack([np.minimum(e1, e2), np.maximum(e1, e2)], axis=1)
-    edge_keys = e1 + self.num_vertices * e2
+    edge_keys = edges[:, 0] + self.num_vertices * edges[:, 1]
     _, unique_indices = np.unique(edge_keys, return_index=True)
     unique_undirected_edges = edges[unique_indices]
     return np.vstack(


### PR DESCRIPTION
## Summary

- derive deduplication keys from canonicalized undirected edge endpoints
- remove duplicate directed edges from `GNM.edge_list`
- add a regression assertion that every returned directed edge is unique

## Root cause

`edge_list` canonicalized each edge as `(min(v1, v2), max(v1, v2))`, but computed uniqueness keys from the original directed endpoints. Shared quad edges commonly appear with opposite winding, so `(u, v)` and `(v, u)` received different keys even though they represented the same undirected edge. Both copies were then expanded in both directions.

## Impact

For GNM Head v3, `edge_list` shrinks from 141,296 rows to 70,946 rows while preserving the same adjacency. All 70,946 returned directed edges are unique.

## Testing

- `python gnm/shape/gnm_numpy_test.py` — 82 passed, 2 skipped
- `python gnm/shape/run_all_tests.py` — 278 passed, 2 skipped
- `pylint gnm/shape/gnm_xnp.py gnm/shape/gnm_numpy_test.py`
