### PR TITLE
Silence Keras progress bars in ExpressionSampler predictions

### DIFF
--- a/gnm/shape/semantic_sampler.py
+++ b/gnm/shape/semantic_sampler.py
@@ -98,7 +98,7 @@ def _get_rng(rng: np.random.Generator | None) -> np.random.Generator:
 
 
 class ExpressionSampler:
-  """Samples expressions and identities from a Conditional VAE."""
+  """Samples expressions from a Conditional VAE."""
 
   def __init__(
       self,
@@ -169,7 +169,9 @@ class ExpressionSampler:
         'float32'
     )
 
-    generated_vectors = self._decoder.predict([z_sample, class_one_hot])
+    generated_vectors = self._decoder.predict(
+        [z_sample, class_one_hot], verbose=0
+    )
     class_name = self._expression_names[class_label]
     if verbose:
       print(
@@ -231,7 +233,7 @@ class ExpressionSampler:
 
     # Decode the blended latent vector and weighted average of one-hot labels
     blended_expression = self._decoder.predict(
-        [blended_latent_vector, blended_one_hot_label]
+        [blended_latent_vector, blended_one_hot_label], verbose=0
     )
     if verbose:
       print(


### PR DESCRIPTION
IdentitySampler already passes verbose=0 to decoder.predict(), but the two ExpressionSampler call sites do not, so every sample_expression and blend_expressions call prints a Keras progress bar. Pass verbose=0 for consistency. Also fixes the ExpressionSampler docstring, which described the class as sampling identities as well.